### PR TITLE
Increase root Browserstack timeout to 10 minutes (600 seconds).

### DIFF
--- a/vsts/config/karma/test.karma.conf.js
+++ b/vsts/config/karma/test.karma.conf.js
@@ -61,6 +61,7 @@ function getConfig(config) {
     browserStack: {
       port: 9876,
       pollingTimeout: 10000,
+      timeout: 600,
       username: args.bsUser,
       accessKey: args.bsKey
     }


### PR DESCRIPTION
https://github.com/karma-runner/karma-browserstack-launcher#global-options passes the root `timeout` property to https://github.com/scottgonzalez/node-browserstack#clientcreateworkersettings-callback which defaults to 300 seconds / 5 minutes.  This will change it to 10.