### PR TITLE
Changing default symbols to non unicode which VSTS does not render well

### DIFF
--- a/vsts/config/karma/test.karma.conf.js
+++ b/vsts/config/karma/test.karma.conf.js
@@ -58,6 +58,17 @@ function getConfig(config) {
     junitReporter: {
       outputDir: path.join(process.cwd(), 'test-results')
     },
+
+    // VSTS doesn't render default symbols well.
+    mochaReporter: {
+      symbols: {
+        success: '+',
+        info: '#',
+        warning: '!',
+        error: 'x'
+      }
+    },
+    
     browserStack: {
       port: 9876,
       pollingTimeout: 10000,


### PR DESCRIPTION
Disabling colors fixed a lot, but the default mocha symbols do not render well in VSTS logs.
https://www.npmjs.com/package/karma-mocha-reporter

<img width="611" alt="screen shot 2018-03-29 at 3 44 11 pm" src="https://user-images.githubusercontent.com/4612419/38110005-1a38cc4c-3368-11e8-81db-4f85234ef129.png">
