### PR TITLE
Enabling watch command

### DIFF
--- a/vsts/config/karma/watch.karma.conf.js
+++ b/vsts/config/karma/watch.karma.conf.js
@@ -1,0 +1,17 @@
+/*jshint node: true*/
+'use strict';
+
+/**
+ * Requires the shared karma config and sets any local properties.
+ * @name getConfig
+ * @param {Object} config
+ */
+function getConfig(config) {
+  require('./test.karma.conf')(config);
+  config.set({
+    autoWatch: true,
+    singleRun: false
+  });
+}
+
+module.exports = getConfig;


### PR DESCRIPTION
To test, you can run `npm install blackbaud/skyux-builder-config#enable-watch`